### PR TITLE
Enable MacOSX support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all byte native: setup.data
 
 configure: setup.data
 setup.data: setup.ml
-	ocaml setup.ml -configure --enable-has-lacaml
+	ocaml setup.ml -configure --enable-lacaml
 
 setup.ml: _oasis
 	oasis setup -setup-update dynamic

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -10,6 +10,7 @@ let fortran =
   try BaseEnvLight.var_get "fortran" env with _ -> failwith "XXX"
 let fortran_lib = BaseEnvLight.var_get "fortran_library" env
 let lbfgsb_ver = BaseEnvLight.var_get "lbfgsb_ver" env
+let fortran_location = BaseEnvLight.var_get "fortran_lib_location" env
 ;;
 dispatch
   (MyOCamlbuildBase.dispatch_combine [
@@ -29,7 +30,19 @@ dispatch
       dep ["c"; "compile"] ("src" / "f2c.h" :: lbfgsb);
 
       (* Add the correct Lbfgsb files for the detected version. *)
-      flag ["ocamlmklib"; "c"] (S(List.map (fun p -> P p) lbfgsb));
+      (* Add the correct Lbfgsb files for the detected version. *)
+      if fortran_lib <> "" then (
+        (* Link the gfortran, so that we can call this in the toplevel.*)
+        let lib_list = [ A"-ldopt"; A("-l" ^ fortran_lib)] in
+        let lib_list =
+          if fortran_location <> "" then
+            A"-ldopt" :: A("-L"^fortran_location) :: lib_list
+          else
+            lib_list
+        in
+        flag ["ocamlmklib"; "c"] (S(List.map (fun p -> P p) lbfgsb @ lib_list));
+      ) else
+        flag ["ocamlmklib"; "c"] (S(List.map (fun p -> P p) lbfgsb));
 
       rule "Fortran to object" ~prod:"%.o" ~dep:"%.f"
         begin fun env _build ->
@@ -42,7 +55,14 @@ dispatch
         end;
 
       if fortran_lib <> "" then (
-        let flib = (S[A"-cclib"; A("-l" ^ fortran_lib)]) in
+        let lib_list = [ A"-cclib"; A("-l" ^ fortran_lib)] in
+        let lib_list =
+          if fortran_location <> "" then
+            A"-ccopt" :: A("-L"^fortran_location) :: lib_list
+          else
+            lib_list
+        in
+        let flib = S lib_list in
         flag ["ocamlmklib"]  flib;
         flag ["extension:cma"]  flib;
         flag ["extension:cmxa"] flib;

--- a/setup.ml
+++ b/setup.ml
@@ -64,6 +64,19 @@ let fortran_lib() =
 
 let _ = BaseEnv.var_define "fortran_library" fortran_lib
 
+let _ =
+  let is_macosx = BaseEnv.var_get "system" = "macosx" in
+  let is_gfortran = fortran_lib () = "gfortran" in
+  if is_macosx && is_gfortran then
+    let com = Printf.sprintf "gfortran --print-file-name libgfortran.dylib" in
+    let ic = Unix.open_process_in com in
+    let line = input_line ic in
+    let _ = close_in ic in
+    let location = Filename.dirname line in
+    BaseEnv.var_define "fortran_lib_location" (fun () -> location)
+  else
+    fun () -> ""
+
 let lbfgsb_ver =
   if Sys.file_exists "src/Lbfgsb.3.0/lbfgsb.f" then "3.0"
   else if Sys.file_exists "src/Lbfgsb.2.1/routines.f" then "2.1"


### PR DESCRIPTION
To that end we locate the gfortran library location, pass it
specifically during compilation and link it into the Lbfgs archive.
