### PR TITLE
OCaml 5.0 compatibility: copy_double -> caml_copy_double

### DIFF
--- a/src/lbfgs_stubs.c
+++ b/src/lbfgs_stubs.c
@@ -93,7 +93,7 @@ value ocaml_lbfgs_setulb(value vn, value vm, value vOFSx, value vx,
           PTR_INT(iprint), String_val(vcsave),
           INT_VEC_DATA(lsave), INT_VEC_DATA(isave), VEC_DATA(dsave));
   /* The following allocates but we do not need Caml arguments anymore: */
-  return(copy_double(f));
+  return(caml_copy_double(f));
 }
 
 CAMLexport


### PR DESCRIPTION
'caml_copy_double' has been present since OCaml 3.08. 'copy_double' was a deprecated alias, which got dropped in OCaml 5.0.

Fixes the following runtime error from the linker:
```
undefined reference to `copy_double'
```

'dune runtest' passes on OCaml 5.0 now.