### PR TITLE
Fix bytecode linking for top-level

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -161,4 +161,5 @@ let () =
   let fortran, cflags, clibs = conf c in
   C.Flags.write_lines "fortranc.txt" [fortran];
   C.Flags.write_sexp "c_flags.sexp" cflags;
-  C.Flags.write_sexp "c_library_flags.sexp" clibs
+  C.Flags.write_sexp "c_library_flags.sexp" clibs;
+  C.Flags.write_lines "c_library_flags.lines" clibs

--- a/src/Lbfgsb.3.0/dune
+++ b/src/Lbfgsb.3.0/dune
@@ -11,7 +11,7 @@
 (rule
  (targets liblbfgs_fortran_stubs.a dlllbfgs_fortran_stubs.so)
  (deps    blas.o lbfgsb.o linpack.o timer.o)
- (action  (run ocamlmklib -o lbfgs_fortran_stubs %{deps})))
+ (action  (run ocamlmklib -o lbfgs_fortran_stubs %{read-lines:c_library_flags.lines} %{deps})))
 
 (rule
  (targets blas.o lbfgsb.o linpack.o timer.o)
@@ -19,6 +19,6 @@
  (action  (run %{read-lines:fortranc.txt} -c -fPIC -O3 %{deps})))
 
 (rule
- (targets c_flags.sexp c_library_flags.sexp fortranc.txt)
+ (targets c_flags.sexp c_library_flags.lines c_library_flags.sexp fortranc.txt)
  (deps ../../config/discover.exe)
  (action (run %{deps})))

--- a/src/lbfgs_stubs.c
+++ b/src/lbfgs_stubs.c
@@ -89,8 +89,8 @@ value ocaml_lbfgs_setulb(value vn, value vm, value vOFSx, value vx,
   setulb_(PTR_INT(n), PTR_INT(m),
           VEC_DATA_OFS(x), VEC_DATA_OFS(l), VEC_DATA_OFS(u), INT_VEC_DATA(nbd),
           &f, VEC_DATA(g), &factr, &pgtol, VEC_DATA(wa), INT_VEC_DATA(iwa),
-          String_val(vtask), /* shared content with OCaml */
-          PTR_INT(iprint), String_val(vcsave),
+          Bytes_val(vtask), /* shared content with OCaml */
+          PTR_INT(iprint), Bytes_val(vcsave),
           INT_VEC_DATA(lsave), INT_VEC_DATA(isave), VEC_DATA(dsave));
   /* The following allocates but we do not need Caml arguments anymore: */
   return(caml_copy_double(f));


### PR DESCRIPTION
I was trying to load `owl-opt-lbfgs` in the top-level and it was failing with a missing symbol.
Trying to load `lbfgs` or `lbfgs.fortran` itself with OCaml 5.0 was failing similarly:
```
    utop # #require "lbfgs.fortran";;
    Cannot load required shared library dlllbfgs_fortran_stubs.
    Reason: /var/home/edwin/.opam/5.0.0-f38/lib/stublibs/dlllbfgs_fortran_stubs.so: /var/home/edwin/.opam/5.0.0-f38/lib/stublibs/dlllbfgs_fortran_stubs.so: undefined symbol: _gfortran_transfer_character_write.
```

Everything was fine when compiled with `ocamlopt`. 
There were  already some dune rules to pass `-lgfortran`, but because `self_build_stubs_archive` was used containing a custom `ocamlmklib` invocation that flag wasn't passed everywhere it should. Ensure `ocamlmklib` gets the appropriate flag, and then I am now able to load `lbfgs` in the top-level.

Also noticed a compile warning about bytes/string mismatch that can be fixed by using the appropriate macros.